### PR TITLE
prevent script error if user enter incorrect max params

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,10 +165,10 @@ let maxIP = urlParams.get('max')
 let testNo = 0;
 let validIPs = [];
 
-if (maxIP === null) {
-  maxIP = 20
-} else {
-  maxIP = parseInt(maxIP);
+maxIP = ~~maxIP;
+
+if (maxIP < 1) {
+  maxIP = 20;
 }
 
 var ips;


### PR DESCRIPTION
if user enter `/?max=abc` then `parseInt()` will return `NaN` so your script break